### PR TITLE
# Fix 31: Submit button for json file and small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ ODAHUFLOWCTL_OAUTH_AUTH_URL=
 JUPYTER_REDIRECT_URL=
 ODAHUFLOWCTL_OAUTH_CLIENT_ID=
 ODAHUFLOWCTL_OAUTH_CLIENT_SECRET=
+PIP_BIN=pip3
 
 -include .env
 
@@ -51,7 +52,7 @@ check-tag:
 
 ## install-jupyterlab-plugin: Install python package for JupyterLab
 install-jupyterlab-plugin:
-	pip3 install ${BUILD_PARAMS} -e .
+	${PIP_BIN} install ${BUILD_PARAMS} -e .
 
 ## docker-build-notebook: Builds docker image with provided parameters
 docker-build-notebook.%:

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     zip_safe=False,
     version=extract_version(),
     install_requires=[
-        'odahu-flow-sdk==1.0.0rc35',
+        'odahu-flow-sdk>=1.1.0',
         'notebook',
         'pydantic>=1.2',
     ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,8 @@ export const EXTENSION_ID = 'jupyter.extensions.jupyter_odahuflow';
 const OPEN_COMMAND = 'template:open';
 const FILE_MANAGER_ODAHUFLOW_RESOURCES = [
   '.jp-DirListing-item[title$=".yaml"]',
-  '.jp-DirListing-item[title$=".yml"]'
+  '.jp-DirListing-item[title$=".yml"]',
+  '.jp-DirListing-item[title$=".json"]'
 ];
 const CONDA_FILES = '.jp-DirListing-item[title*="conda.yaml"]';
 const APPLY_ODAHUFLOW_RESOURCES = 100;


### PR DESCRIPTION
* In JupyterLab extension, the 'submit' button should be available in the context menu for .json files the same as for .yaml files.
* Add .gitignore
* Add stable 1.1.0 sdk version as dependency
* Add ability to override default pip binary for Makefile