### PR TITLE
[#46] Fix: when the valid deployment is submitted, the error is shown…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     zip_safe=False,
     version=extract_version(),
     install_requires=[
-        'odahu-flow-sdk>=1.1.0',
+        'odahu-flow-sdk==1.4.0rc5',
         'notebook',
         'pydantic>=1.2',
     ],


### PR DESCRIPTION
… that 'the predictor parameter is empty' while the predictor parameter is passed

fixes #46 